### PR TITLE
Add a remove_dir_optional()

### DIFF
--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -31,7 +31,10 @@ fn dir_tests() -> Result<()> {
     assert_eq!(0, bar.list_dir(".")?.count());
 
     assert!(!d.exists("baz")?);
+    assert!(!d.remove_dir_optional("baz")?);
     d.ensure_dir("baz", 0o755)?;
+    assert!(d.remove_dir_optional("baz")?);
+    assert!(!d.exists("baz")?);
 
     Ok(())
 }


### PR DESCRIPTION
Matches `remove_file_optional()`.  I noticed this lack
when implementing the `remove_all()` API.  Basically we don't
want to error out if something else is racing with us to delete.