### PR TITLE
remove_all: Fix removal of symlinks that point to directories

### DIFF
--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -181,6 +181,10 @@ fn rmrf() -> anyhow::Result<()> {
         create_dir_all(&p)?;
         symlink("/", p.join("somelink"))?;
         symlink("somelink", p.join("otherlink"))?;
+        symlink(".", p.join("link2self"))?;
+        let linkeddir = p.join("linkdirtarget");
+        create_dir_all(&linkeddir)?;
+        symlink(&linkeddir, p.join("link2dir"))?;
     }
     for f in &["somefile", "otherfile"] {
         fswrite(td.join("foo/bar").join(f), f)?;


### PR DESCRIPTION
This is an evil trap with `O_PATH` plus the fact that `list_dir`
follows symlinks by default.  We were using `list_dir` as a way
to detect symlinks.  Instead try removing it as a file first,
and use the directory path if we get `EISDIR`.