### PR TITLE
Fix write_file_with() to be FnOnce

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub trait OpenatDirExt {
         f: F,
     ) -> Result<T, E>
     where
-        F: Fn(&mut std::io::BufWriter<std::fs::File>) -> Result<T, E>,
+        F: FnOnce(&mut std::io::BufWriter<std::fs::File>) -> Result<T, E>,
         E: From<io::Error>,
     {
         let mut w = self.new_file_writer(destname, mode)?;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -85,6 +85,14 @@ fn write_file_with() -> Result<()> {
     })?;
     let actual_contents = std::fs::read_to_string(td.path().join(testname))?;
     assert_eq!(testcontents2, actual_contents.as_str());
+    let srcf = d.open_file("testfile")?;
+    d.write_file_with("testfile2", 0o644, |w| -> anyhow::Result<()> {
+        let mut bufr = std::io::BufReader::new(srcf);
+        std::io::copy(&mut bufr, w)?;
+        Ok(())
+    })?;
+    let actual_contents = std::fs::read_to_string(td.path().join("testfile2"))?;
+    assert_eq!(testcontents2, actual_contents.as_str());
     Ok(())
 }
 


### PR DESCRIPTION
https://github.com/coreos/rpm-ostree/pull/2580#discussion_r578421894

We only call it once, let's make it easy to pass in mutable state.