### PR TITLE
0.2.0 patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "openat-ext"
 description = """
     Extension methods for the openat crate
 """
-version = "0.1.14-alpha.0"
+version = "0.2.0"
 authors = ["Colin Walters <walters@verbum.org>"]
 edition = "2018"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ homepage = "http://github.com/coreos/openat-ext"
 documentation = "http://docs.rs/openat-ext"
 
 [dependencies]
-drop_bomb = "0.1.5"
 openat = "0.1.15"
 libc = "0.2.34"
 nix = "0.18"

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -148,7 +148,6 @@ fn file_writer_abandon() -> Result<()> {
     {
         let mut fw = d.new_file_writer(0o644)?;
         fw.writer.write_all(testcontents.as_bytes())?;
-        fw.abandon();
     }
     assert!(d.open_file_optional(testname)?.is_none());
     Ok(())

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -131,9 +131,9 @@ fn file_writer() -> Result<()> {
     let d = openat::Dir::open(td.path())?;
     let testname = "testfile";
     let testcontents = "hello world";
-    let mut fw = d.new_file_writer(testname, 0o644)?;
+    let mut fw = d.new_file_writer(0o644)?;
     fw.writer.write_all(testcontents.as_bytes())?;
-    fw.complete()?;
+    fw.complete(testname)?;
     let actual_contents = std::fs::read_to_string(td.path().join(testname))?;
     assert_eq!(testcontents, actual_contents.as_str());
     Ok(())
@@ -146,7 +146,7 @@ fn file_writer_abandon() -> Result<()> {
     let testname = "testfile";
     let testcontents = "hello world";
     {
-        let mut fw = d.new_file_writer(testname, 0o644)?;
+        let mut fw = d.new_file_writer(0o644)?;
         fw.writer.write_all(testcontents.as_bytes())?;
         fw.abandon();
     }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -155,29 +155,6 @@ fn file_writer_abandon() -> Result<()> {
 }
 
 #[test]
-fn file_writer_panic() -> Result<()> {
-    let td = tempfile::tempdir()?;
-    let d = openat::Dir::open(td.path())?;
-    let result = std::panic::catch_unwind(move || -> std::io::Result<()> {
-        let _fw = d
-            .new_file_writer("sometestfile", 0o644)
-            .expect("new writer");
-        Ok(())
-    });
-    match result {
-        Ok(_) => panic!("expected panic from FileWriter"),
-        Err(e) => {
-            if let Some(s) = e.downcast_ref::<String>() {
-                assert!(s.contains("FileWriter must be explicitly"));
-            } else {
-                panic!("Unexpected panic")
-            }
-        }
-    }
-    Ok(())
-}
-
-#[test]
 fn rmrf() -> anyhow::Result<()> {
     use std::fs::create_dir_all;
     use std::fs::write as fswrite;


### PR DESCRIPTION
FileWriter: Remove drop bomb usage

In practice, we should match the rest of the ecosystem and have
our drop handler just silently delete the file.  This works
much better with complex error handling scenarios.

Motivated by trying to use this in another library.

---

[0.2.0] Change remove_file_optional to return a bool

This came up in review, we can do this for 0.2.0.

---

[0.2.0] FileWriter: Move name to `complete()` function

I'm working on a project that wants to name the file after
it sha256 (like ostree/git), and the name hence needs to be passed
when the file is written, not when it's created.

---

[0.2.0] FileWriter: Abandon abandon()

Actually now that we've removed the drop bomb, we might as well
just use the default `Drop` handling here.  This simplifies the callers.

---

version: Bump to 0.2.0

---

