### PR TITLE
OpenatDirExt: add syncfs helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "http://docs.rs/openat-ext"
 
 [dependencies]
 openat = "0.1.15"
-libc = "0.2.34"
+libc = "^0.2.94"
 nix = ">= 0.18, < 0.21"
 rand = "0.8.3"
 


### PR DESCRIPTION
This adds an helper method for `syncfs`, which carries additional
logic to handle the O_PATH FD.

It requires a dependency bump in order to use `libc::syncfs`.