### PR TITLE
Deprecate this crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
+# This project is deprecated
+
+Still maintained for now, but deprecated.
+Instead, we are focusing on [cap-std](https://docs.rs/cap-std/latest/cap_std/)
+and the successor to this crate is [cap-std-ext](https://docs.rs/cap-std-ext/latest/cap_std_ext/).
+
 Helpers for the openat crate
 ====
+
 
 See https://crates.io/crates/openat
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//! # This crate is deprecated
+//!
+//! This crate is deprecated.  Development has shifted to the
+//! [cap-std](https://docs.rs/cap-std/latest/cap_std/) ecosystem,
+//! and the successor to this crate is [cap-std-ext](https://docs.rs/cap-std-ext/latest/cap_std_ext/).
+//!
 //! # Extension methods for openat::Dir and std::fs::File
 //!
 //! ```


### PR DESCRIPTION
This crate is deprecated.  Development has shifted to the
[cap-std](https://docs.rs/cap-std/latest/cap_std/) ecosystem,
and the successor to this crate is [cap-std-ext](https://docs.rs/cap-std-ext/latest/cap_std_ext/).