### PR TITLE
Bump to nix 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "http://docs.rs/openat-ext"
 [dependencies]
 openat = "0.1.15"
 libc = "^0.2.94"
-nix = ">= 0.22, < 0.23"
+nix = "0.23"
 rand = "0.8.3"
 
 [dev-dependencies]


### PR DESCRIPTION
This is the latest version, and will help avoid multiple
versions of nix in at least the rpm-ostree depchain.

I think the reason we were pinning to `< 0.23` around the `bitflags`
crate snafu is fixed now.