### PR TITLE
Implement Packit to openat-ext

### DIFF
--- a/tests/.packit.yaml
+++ b/tests/.packit.yaml
@@ -1,0 +1,34 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+upstream_project_url: https://github.com/coreos/openat-ext
+
+upstream_tag_template: v{version}
+
+specfile_path: basic.rs
+
+files_to_sync:
+    - .packit.yaml
+
+upstream_package_name: openat-ext
+
+jobs: 
+
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+    - fedora-rawhide
+    - fedora-stable
+
+- job: koji_build
+  trigger: commit
+  dist_git_branches:
+    - fedora-rawhide
+    - fedora-stable
+
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - fedora-stable
+
+


### PR DESCRIPTION
This PR is about using Packit to automate releases for [openat-ext](https://github.com/coreos/openat-ext). We tested it in coreos-installer and found it effective. Now, we're working in an epic to add it in all coreos packages repos. 

You can learn more about Packit in its documentation [here](https://packit.dev/docs).